### PR TITLE
Possibility to store all resources in a well defined absolute path

### DIFF
--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -17,6 +17,22 @@
 #include "util.h"
 #include <SDL2/SDL.h>
 
+std::string s_ResourcePath = "./res/";
+
+void Util::Init( const char *app, const char *org )
+{
+  if ( SDL_strcmp( app, "" ) != 0 )
+  {
+    char *base_path = SDL_GetPrefPath( org, app );
+
+    if ( base_path ) {
+        s_ResourcePath = SDL_strdup( base_path );
+
+        SDL_free(base_path);
+    }
+  }
+}
+
 void Util::Sleep(int milliseconds)
 {
 	SDL_Delay(milliseconds);
@@ -46,4 +62,9 @@ std::vector<std::string> Util::Split(const std::string& s, char delim)
     }
         
     return elems;
+}
+
+std::string Util::ResourcePath( void )
+{
+  return s_ResourcePath;
 }

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -49,8 +49,26 @@
 
 namespace Util
 {
+  /**
+   * Initializes a directory for central resource managment.
+   * Under Linux, the path will be /home/user/.local/share/{org}/{app}/
+   * Under Windows, the path will be SYSTEMDRIVE:\\Users\\user\\AppData\\Roaming\\{orf}\\{app}\\
+   * Under Mac OS X, the path will be /Users/user/Library/Application Support/{app}/
+   *
+   * If you set app as an empty string "", than old folder structure will be used.
+   *
+   * More Information on https://wiki.libsdl.org/SDL_GetPrefPath
+   *
+   * \param app Defines the name of this application
+   * \param org Defines the organization name
+   */
+  void Init( const char *app, const char *org = "3DEngineCpp" );
 	void Sleep(int milliseconds);
 	std::vector<std::string> Split(const std::string &s, char delim);
+	/**
+	 * Returns the resource path.
+	 */
+	std::string ResourcePath( void );
 };
 
 #endif

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -52,7 +52,7 @@ namespace Util
   /**
    * Initializes a directory for central resource managment.
    * Under Linux, the path will be /home/user/.local/share/{org}/{app}/
-   * Under Windows, the path will be SYSTEMDRIVE:\\Users\\user\\AppData\\Roaming\\{orf}\\{app}\\
+   * Under Windows, the path will be SYSTEMDRIVE:\\Users\\user\\AppData\\Roaming\\{org}\\{app}\\
    * Under Mac OS X, the path will be /Users/user/Library/Application Support/{app}/
    *
    * If you set app as an empty string "", than old folder structure will be used.

--- a/src/rendering/mesh.cpp
+++ b/src/rendering/mesh.cpp
@@ -16,6 +16,7 @@
 
 #include "mesh.h"
 
+#include "../core/util.h"
 #include "../core/profiling.h"
 
 #include <GL/glew.h>
@@ -256,7 +257,7 @@ Mesh::Mesh(const std::string& fileName) :
 	{
 		Assimp::Importer importer;
 		
-		const aiScene* scene = importer.ReadFile(("./res/models/" + fileName).c_str(), 
+		const aiScene* scene = importer.ReadFile((Util::ResourcePath() + "models/" + fileName).c_str(),
 		                                         aiProcess_Triangulate |
 		                                         aiProcess_GenSmoothNormals | 
 		                                         aiProcess_FlipUVs |

--- a/src/rendering/shader.cpp
+++ b/src/rendering/shader.cpp
@@ -478,7 +478,7 @@ static void CheckShaderError(int shader, int flag, bool isProgram, const std::st
 static std::string LoadShader(const std::string& fileName)
 {
 	std::ifstream file;
-	file.open(("./res/shaders/" + fileName).c_str());
+	file.open((Util::ResourcePath() + "shaders/" + fileName).c_str());
 
 	std::string output;
 	std::string line;

--- a/src/rendering/texture.cpp
+++ b/src/rendering/texture.cpp
@@ -16,6 +16,7 @@
 
 #include "texture.h"
 
+#include "../core/util.h"
 #include "../core/math3d.h"
 #include "../core/profiling.h"
 
@@ -177,7 +178,7 @@ Texture::Texture(const std::string& fileName, GLenum textureTarget, GLfloat filt
 	else
 	{
 		int x, y, bytesPerPixel;
-		unsigned char* data = stbi_load(("./res/textures/" + fileName).c_str(), &x, &y, &bytesPerPixel, 4);
+		unsigned char* data = stbi_load((Util::ResourcePath() + "textures/" + fileName).c_str(), &x, &y, &bytesPerPixel, 4);
 
 		if(data == NULL)
 		{

--- a/src/rendering/window.cpp
+++ b/src/rendering/window.cpp
@@ -16,6 +16,7 @@
 
 #include "window.h"
 #include "../core/profiling.h"
+#include "../core/util.h"
 #include <SDL2/SDL.h>
 #include <GL/glew.h>
 
@@ -57,6 +58,11 @@ Window::Window(int width, int height, const std::string& title) :
 	{
 		fprintf(stderr, "Error: '%s'\n", glewGetErrorString(res));
 	}
+
+  Util::Init( "" );
+// Uses the relatice ./res/ folder as resource directory.
+// Use the following line to use the absolute path in your users local directory.
+//  Util::Init( title.c_str() );
 }
 
 Window::~Window()


### PR DESCRIPTION
I've got many times trouble with the right working directory for the res folder. With [SDL_GetPrefPath()](https://wiki.libsdl.org/SDL_GetPrefPath) there is a opportunity to get a native filesystem path, so the working directory for calling the binary doesn't need to be in the same directory.

If you want to use the new path system, copy one time all folder inside the res folder into the generated folder by SDL and you are good to go.
The path will be created after glewInit inside the Window constructor and is set, so you use the current system, uncomment the marked line to use the new system.
