### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 It's like the 3D Game Engine, except in C++
 
-##Build Dependencies##
+## Build Dependencies ##
 - [CMAKE](http://www.cmake.org/)
 - [GLEW](http://glew.sourceforge.net/)
 - [SDL2](http://www.libsdl.org/)
@@ -20,7 +20,7 @@ It's like the 3D Game Engine, except in C++
 		- [Visual Studio](http://www.visualstudio.com/)
 		- [CodeBlocks](http://www.codeblocks.org/)
 
-###NOTES for Dependencies###
+### NOTES for Dependencies ###
 On Unix/Linux/Mac you can likely install CMAKE, GLEW, SDL2 and ASSIMP with your package manager
 ```shell
 # On ubuntu just run
@@ -30,8 +30,8 @@ sudo apt-get install cmake libglew-dev libsdl2-dev libassimp-dev
 brew install cmake glew sdl2 assimp
 ```
 
-##Simple Build Instructions##
-###Mac OSX/Linux/Unix###
+## Simple Build Instructions ##
+### Mac OSX/Linux/Unix ###
 - Open a Terminal and run:
 ```Shell
 # install dependencies
@@ -44,15 +44,15 @@ brew install cmake glew sdl2 assimp
 ```
 - If this fails for any reason, try using the Manual Build Instructions below.
 
-###Windows###
+### Windows ###
 - Make sure CMake is both installed and added to the system PATH.
 - Run "Windows-GenVisualStudioProject.bat" If this fails for any reason, try using the Manual Build Instructions below.
 - Go to the build folder, and open 3DEngineCpp.sln with Visual Studio 2012 or newer (For older versions of Visual Studio, use manual build instructions)
 - Right click on the 3DEngineCpp project, and select "Set as start up project"
 - Build and Run
 
-##Manual Build Instructions##
-###Linux/Unix###
+## Manual Build Instructions ##
+### Linux/Unix ###
 - Open a Terminal and run:
 ```Shell
 # install dependencies
@@ -61,7 +61,7 @@ cmake ../
 make
 ```
 
-###Mac OSX###
+### Mac OSX ###
 - Open a Terminal and run:
 ```Shell
 # install dependencies
@@ -70,7 +70,7 @@ cmake ../
 make
 ```
 
-###Windows/MinGW###
+### Windows/MinGW ###
 - Make sure CMake is both installed and added to the system PATH.
 - Open a Terminal and run:
 ```Shell
@@ -89,7 +89,7 @@ cmake -G "Visual Studio 12" ../
 - Move the res folder into the build folder
 - Run
 
-##Additional Credits##
+## Additional Credits ##
 - Etay Meiri, for http://ogldev.atspace.co.uk/ which inspired the base code for this repository.
 - [@mxaddict](https://github.com/mxaddict) for setting up the awesome CMake build system
 - Everyone who's created or contributed to issues and pull requests, which make the project better!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
